### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node_extra_ca_certs_mozilla_bundle": "^1.0.4",
     "nodemailer": "^6.7.5",
     "pug": "^3.0.2",
-    "socket.io": "^4.5.0",
+    "socket.io": "^4.7.5",
     "ssl-root-cas": "^1.3.1"
   }
 }


### PR DESCRIPTION
According to the page: https://www.npmjs.com/package/socket.io

I have added 4.7.5 as the latest version of socket.io

However, the caret (^) symbol already incorporates the latest available version.